### PR TITLE
Update package version to 2.0.1 and add TypeScript definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@to-kn/koa-locales",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@to-kn/koa-locales",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@to-kn/koa-locales",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "koa locales, i18n solution for koa",
 	"keywords": [
 		"koa-locales",
@@ -23,7 +23,8 @@
 	"type": "module",
 	"exports": {
 		"import": "./dist/esm/index.js",
-		"require": "./dist/cjs/index.cjs"
+		"require": "./dist/cjs/index.cjs",
+		"types": "./dist/types/index.d.ts"
 	},
 	"main": "./dist/esm/index.js",
 	"module": "./dist/esm/index.js",


### PR DESCRIPTION
- Bumped the version in package.json and package-lock.json from 2.0.0 to 2.0.1.
- Added TypeScript definitions path in the exports section of package.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 2.0.1.
  * Exposed TypeScript type definitions for easier access by consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->